### PR TITLE
chore: Remove postgers db, prelace with neon.tech

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
 TELEGRAM_TOKEN=
 DATABASE_URL=sqlite:///dev.db
+# Production uses Neon (neon.tech) serverless PostgreSQL:
+# DATABASE_URL=postgresql://user:pass@ep-xxx.eu-central-1.aws.neon.tech/neondb?sslmode=require
 # WEBHOOK=            # omit for local polling mode
 # PORT=8443

--- a/render.yaml
+++ b/render.yaml
@@ -11,11 +11,4 @@ services:
       - key: WEBHOOK
         sync: false
       - key: DATABASE_URL
-        fromDatabase:
-          name: quizbot-db
-          property: connectionString
-
-databases:
-  - name: quizbot-db
-    plan: free
-    region: frankfurt
+        sync: false


### PR DESCRIPTION
## Summary

This pull request updates environment configuration and deployment settings to better align with production requirements and simplify local development. The most important changes are grouped below:

Environment configuration improvements:

* Added a commented example for a production `DATABASE_URL` using Neon serverless PostgreSQL in `.env.example`, clarifying the recommended setup for production deployments.

Deployment configuration simplification:

* Removed the automatic database provisioning and connection string mapping for the `DATABASE_URL` in `render.yaml`, making the deployment configuration less dependent on Render's managed databases and more flexible for external database setups.

## Test plan

<!-- How was this tested? -->

- [x] Existing tests pass (`uv run pytest tests/`)
