### PR TITLE
feat: Add fallback handler

### DIFF
--- a/quizbot/bot/bot.py
+++ b/quizbot/bot/bot.py
@@ -93,6 +93,14 @@ def setup_bot(app):
     # help command
     app.add_handler(CommandHandler("help", print_help))
 
+    # fallback for unrecognized messages
+    async def unknown(update, _):
+        await update.message.reply_text(
+            "I don't understand that. Use /help to see what I can do."
+        )
+    app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, unknown))
+    app.add_handler(MessageHandler(filters.COMMAND, unknown))
+
     # log all errors
     app.add_error_handler(error)
 


### PR DESCRIPTION
## Summary

This pull request adds a fallback handler to the bot so that it responds gracefully to unrecognized messages and commands by informing users about the `/help` command.

Bot user experience improvements:

* Added an `unknown` handler to reply with a helpful message when the bot receives unrecognized text or commands, guiding users to use `/help` for available actions. (`quizbot/bot/bot.py`)
